### PR TITLE
Modernize and java1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ test-output
 target
 release.properties
 .settings
+/kbop.iml
+/.idea

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,21 @@
 					<finalName>${artifactId}-${release.version}</finalName>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>3.1.6</version>
+				<!-- this will make findbugs run during mvn verify -->
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-					<proc>none</proc>
+					<source>1.7</source>
+					<target>1.7</target>
+					<encoding>UTF-8</encoding>
+					<compilerArgument>-Xlint:all</compilerArgument>
+					<useIncrementalCompilation>false</useIncrementalCompilation>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -70,7 +73,16 @@
 			</plugin>
 		</plugins>
 	</build>
+
 	<dependencies>
+		<dependency><!-- Gives us @NotNull and @Nullable -->
+			<groupId>org.jetbrains</groupId>
+			<artifactId>annotations</artifactId>
+			<version>16.0.2</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
@@ -78,6 +90,7 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
 	<reporting>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,24 @@
 		<developer>
 			<name>Jeremy Unruh</name>
 			<url>http://www.pacesys.org</url>
+			<roles>
+				<role>developer</role>
+				<role>packager</role>
+			</roles>
 		</developer>
 	</developers>
+
+	<contributors>
+		<contributor>
+			<name>Benny Bottema</name>
+			<email>benny@bennybottema.com</email>
+			<url>http://www.bennybottema.com</url>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>Europe/Amsterdam</timezone>
+		</contributor>
+	</contributors>
 
 	<scm>
 		<connection>scm:git:git@github.com:gondor/kbop.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,31 @@
 					<useIncrementalCompilation>false</useIncrementalCompilation>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>se.eris</groupId>
+				<artifactId>notnull-instrumenter-maven-plugin</artifactId>
+				<version>0.6.8</version>
+				<executions>
+					<execution>
+						<id>instrument</id>
+						<goals>
+							<goal>instrument</goal>
+							<goal>tests-instrument</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<implicit>true</implicit>
+					<nullable>
+						<param>org.jetbrains.annotations.Nullable</param>
+					</nullable>
+					<notNull>
+						<param>org.jetbrains.annotations.NotNull</param>
+					</notNull>
+				</configuration>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
 	</build>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.2</version>
+			<scope>provided</scope>
+		</dependency>
 		<dependency><!-- Gives us @NotNull and @Nullable -->
 			<groupId>org.jetbrains</groupId>
 			<artifactId>annotations</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,17 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- test dependencies -->
+		<!-- testing dependencies-->
 		<dependency>
-			<groupId>org.testng</groupId>
-			<artifactId>testng</artifactId>
-			<version>6.5.2</version>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.8.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>2.9.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/pacesys/kbop/IKeyedObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/IKeyedObjectPool.java
@@ -1,108 +1,107 @@
 package org.pacesys.kbop;
 
+import org.pacesys.kbop.PoolMetrics.PoolMultiMetrics;
+
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.pacesys.kbop.PoolMetrics.PoolMultiMetrics;
-
 /**
- * Keyed Object Pool which associates Object(s) available to borrow against a Key.  When an object is borrowed the thread who obtained it has full rights
- * to use the object as well as the ability to keep borrowing until the Object is finally released back into the pool signally other waiting threads the right to
- * borrow the same object.
- * 
+ * Keyed Object Pool which associates Object(s) available to borrow against a Key.  When an object is borrowed the thread who obtained it has full rights to use the object as well as the ability to
+ * keep borrowing until the Object is finally released back into the pool signally other waiting threads the right to borrow the same object.
+ *
  * @param <K> the key type
  * @param <V> the Object being borrowed Type
  */
 public interface IKeyedObjectPool<K, V> {
-
+	
 	/**
 	 * Determines if the Pool is currently Shutdown (borrowing is prohibited)
 	 *
 	 * @return true, if is shutdown
 	 */
 	boolean isShutdown();
-
+	
 	/**
-	 * Attempts to borrow an Object from the Pool with the given Key.  Please note that upon successful retrieval of the borrowed object it is
-	 * up to the borrower to {@link #release(IPooledObject)} the object back into the Pool when complete.  This pool has no cleanup threads
-	 * and it is the responsibility of the borrower to properly release the borrowed Object.  Failure to do so when prevent other threads from borrowing the
-	 * object.
-	 * 
-	 * This call will block until the Object associated with the Key is available.  If more control is desired then see {@link #borrow(K, long, TimeUnit)} which 
-	 * allows a max time to wait
+	 * Attempts to borrow an Object from the Pool with the given Key.  Please note that upon successful retrieval of the borrowed object it is up to the borrower to {@link #release(IPooledObject)} the
+	 * object back into the Pool when complete.  This pool has no cleanup threads and it is the responsibility of the borrower to properly release the borrowed Object.  Failure to do so when prevent
+	 * other threads from borrowing the object.
+	 * <p>
+	 * This call will block until the Object associated with the Key is available.  If more control is desired then see {@link #borrow(K, long, TimeUnit)} which allows a max time to wait
 	 *
 	 * @param key the Pool Key used to lookup the Object to borrow
+	 *
 	 * @return the IPooledObject which is a wrapper for the borrowed Object
 	 * @throws IllegalStateException if the Pool has been shutdown
-	 * @throws Exception  if the thread was interrupted or an error occurred during the creation of a new Object which didn't exist in the Pool.
+	 * @throws Exception             if the thread was interrupted or an error occurred during the creation of a new Object which didn't exist in the Pool.
 	 */
 	IPooledObject<V, K> borrow(K key) throws Exception;
-
+	
 	/**
-	 * Attempts to borrow an Object from the Pool with the given Key.  Please note that upon successful retrieval of the borrowed object it is
-	 * up to the borrower to {@link #release(IPooledObject)} the object back into the Pool when complete.  This pool has no cleanup threads
-	 * and it is the responsibility of the borrower to properly release the borrowed Object.  Failure to do so when prevent other threads from borrowing the
-	 * object.
-	 * 
-	 * This call will Block until the specified {@code timeout and unit}.  If the object is not available during the specified time then a TimeoutException
-	 * will be thrown.
+	 * Attempts to borrow an Object from the Pool with the given Key.  Please note that upon successful retrieval of the borrowed object it is up to the borrower to {@link #release(IPooledObject)} the
+	 * object back into the Pool when complete.  This pool has no cleanup threads and it is the responsibility of the borrower to properly release the borrowed Object.  Failure to do so when prevent
+	 * other threads from borrowing the object.
+	 * <p>
+	 * This call will Block until the specified {@code timeout and unit}.  If the object is not available during the specified time then a TimeoutException will be thrown.
 	 *
-	 * @param key the Pool Key used to lookup the Object to borrow
-	 * @param  timeout the maximum time to wait
-	 * @param unit the time unit of the timeout argument
+	 * @param key     the Pool Key used to lookup the Object to borrow
+	 * @param timeout the maximum time to wait
+	 * @param unit    the time unit of the timeout argument
+	 *
 	 * @return the IPooledObject which is a wrapper for the borrowed Object
-	 * @throws TimeoutException if the wait timed out
+	 * @throws TimeoutException      if the wait timed out
 	 * @throws IllegalStateException if the Pool has been shutdown
-	 * @throws Exception if the thread was interrupted or an error occurred during the creation of a new Object which didn't exist in the Pool.
+	 * @throws Exception             if the thread was interrupted or an error occurred during the creation of a new Object which didn't exist in the Pool.
 	 */
 	IPooledObject<V, K> borrow(K key, long timeout, TimeUnit unit) throws TimeoutException, Exception;
-
+	
 	/**
 	 * Releases the Borrowed Object back into the Pool and makes it available for borrowing
 	 *
 	 * @param borrowedObject the object to release
 	 */
 	void release(IPooledObject<V, K> borrowedObject);
-
+	
 	/**
-	 * Releases the object from the pool and removes it.  If the key associated with this object no longer has available object(s)
-	 * to borrow against depending on the Pool Configuration then a new object will be created on the next request.
-	 * 
+	 * Releases the object from the pool and removes it.  If the key associated with this object no longer has available object(s) to borrow against depending on the Pool Configuration then a new
+	 * object will be created on the next request.
+	 *
 	 * @param borrowedObject the object to release and invalidate
 	 */
 	void invalidate(IPooledObject<V, K> borrowedObject);
-
+	
 	/**
 	 * Shuts down the current Pool stopping Allocations
 	 */
 	void shutdown();
-
+	
 	/**
 	 * Single Key to Multi Object Pool.  See {@link IKeyedObjectPool} for extended documentation
-	 * 
+	 *
 	 * @param <K> the key type
 	 * @param <V> the Object being borrowed Type
 	 */
 	interface Multi<K, V> extends IKeyedObjectPool<K, V> {
 		/**
 		 * Calculates current metrics and returns a snapshot of Borrowed, Waiting counts and more
+		 *
 		 * @return PoolMetrics
 		 */
 		PoolMultiMetrics<K> getPoolMetrics();
 	}
-
+	
 	/**
 	 * Single Key to Single Object Pool.  See {@link IKeyedObjectPool} for extended documentation
-	 * 
+	 *
 	 * @param <K> the key type
 	 * @param <V> the Object being borrowed Type
 	 */
 	interface Single<K, V> extends IKeyedObjectPool<K, V> {
 		/**
 		 * Calculates current metrics and returns a snapshot of Borrowed, Waiting counts and more
+		 *
 		 * @return PoolMetrics
 		 */
 		PoolMetrics getPoolMetrics();
 	}
-
+	
 }

--- a/src/main/java/org/pacesys/kbop/IKeyedObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/IKeyedObjectPool.java
@@ -74,13 +74,6 @@ public interface IKeyedObjectPool<K, V> {
 	void invalidate(IPooledObject<V, K> borrowedObject);
 
 	/**
-	 * Clears the specified pool, removing all pooled instances corresponding to the given key.  Depending on the underlying Pool Implementation this
-	 * method call may be ignored.  
-	 * @param key the key to clear
-	 */
-	void clear(K key);
-
-	/**
 	 * Shuts down the current Pool stopping Allocations
 	 */
 	void shutdown();

--- a/src/main/java/org/pacesys/kbop/IKeyedObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/IKeyedObjectPool.java
@@ -105,7 +105,7 @@ public interface IKeyedObjectPool<K, V> {
 		 * Calculates current metrics and returns a snapshot of Borrowed, Waiting counts and more
 		 * @return PoolMetrics
 		 */
-		PoolMetrics<K> getPoolMetrics();
+		PoolMetrics getPoolMetrics();
 	}
 
 }

--- a/src/main/java/org/pacesys/kbop/IKeyedObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/IKeyedObjectPool.java
@@ -37,7 +37,7 @@ public interface IKeyedObjectPool<K, V> {
 	 * @throws IllegalStateException if the Pool has been shutdown
 	 * @throws Exception  if the thread was interrupted or an error occurred during the creation of a new Object which didn't exist in the Pool.
 	 */
-	IPooledObject<V> borrow(K key) throws Exception;
+	IPooledObject<V, K> borrow(K key) throws Exception;
 
 	/**
 	 * Attempts to borrow an Object from the Pool with the given Key.  Please note that upon successful retrieval of the borrowed object it is
@@ -56,14 +56,14 @@ public interface IKeyedObjectPool<K, V> {
 	 * @throws IllegalStateException if the Pool has been shutdown
 	 * @throws Exception if the thread was interrupted or an error occurred during the creation of a new Object which didn't exist in the Pool.
 	 */
-	IPooledObject<V> borrow(K key, long timeout, TimeUnit unit) throws TimeoutException, Exception;
+	IPooledObject<V, K> borrow(K key, long timeout, TimeUnit unit) throws TimeoutException, Exception;
 
 	/**
 	 * Releases the Borrowed Object back into the Pool and makes it available for borrowing
 	 *
 	 * @param borrowedObject the object to release
 	 */
-	void release(IPooledObject<V> borrowedObject);
+	void release(IPooledObject<V, K> borrowedObject);
 
 	/**
 	 * Releases the object from the pool and removes it.  If the key associated with this object no longer has available object(s)
@@ -71,7 +71,7 @@ public interface IKeyedObjectPool<K, V> {
 	 * 
 	 * @param borrowedObject the object to release and invalidate
 	 */
-	void invalidate(IPooledObject<V> borrowedObject);
+	void invalidate(IPooledObject<V, K> borrowedObject);
 
 	/**
 	 * Clears the specified pool, removing all pooled instances corresponding to the given key.  Depending on the underlying Pool Implementation this

--- a/src/main/java/org/pacesys/kbop/IKeyedObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/IKeyedObjectPool.java
@@ -12,7 +12,6 @@ import org.pacesys.kbop.PoolMetrics.PoolMultiMetrics;
  * 
  * @param <K> the key type
  * @param <V> the Object being borrowed Type
- * @author Jeremy Unruh
  */
 public interface IKeyedObjectPool<K, V> {
 
@@ -83,7 +82,6 @@ public interface IKeyedObjectPool<K, V> {
 	 * 
 	 * @param <K> the key type
 	 * @param <V> the Object being borrowed Type
-	 * @author Jeremy Unruh
 	 */
 	interface Multi<K, V> extends IKeyedObjectPool<K, V> {
 		/**
@@ -98,7 +96,6 @@ public interface IKeyedObjectPool<K, V> {
 	 * 
 	 * @param <K> the key type
 	 * @param <V> the Object being borrowed Type
-	 * @author Jeremy Unruh
 	 */
 	interface Single<K, V> extends IKeyedObjectPool<K, V> {
 		/**

--- a/src/main/java/org/pacesys/kbop/IPoolObjectFactory.java
+++ b/src/main/java/org/pacesys/kbop/IPoolObjectFactory.java
@@ -6,8 +6,6 @@ package org.pacesys.kbop;
  *
  * @param <K> the key type
  * @param <V> the value type
- * 
- * @author Jeremy Unruh
  */
 public interface IPoolObjectFactory<K, V> {
 

--- a/src/main/java/org/pacesys/kbop/IPoolObjectFactory.java
+++ b/src/main/java/org/pacesys/kbop/IPoolObjectFactory.java
@@ -1,41 +1,41 @@
 package org.pacesys.kbop;
 
 /**
- * A Factory which is responsible for creating the Object (V) based on the Pool Key.  The returned Object will be wrapped in a {@link IPooledObject} and inserted into the
- * Pool for access
+ * A Factory which is responsible for creating the Object (V) based on the Pool Key.  The returned Object will be wrapped in a {@link IPooledObject} and inserted into the Pool for access
  *
  * @param <K> the key type
  * @param <V> the value type
  */
 public interface IPoolObjectFactory<K, V> {
-
-  /**
-   * Creates the defined Object V based on the current Pool Key.
-   *
-   * @param key the key being requested
-   * @return the Object to be inserted into the Pool
-   */
-  V create(PoolKey<K> key);
-
-  /**
-   * Reinitialize an instance to be returned to the borrower
-   *
-   * @param object the object being borrowed
-   */
-  void activate(V object);
-
-  /**
-   * Uninitialize an instance which has been released back to the pool
-   *
-   * @param object the object to which has just beel released
-   */
-  void passivate(V object);
-
-  /**
-   * Destroy an instance no longer needed by the pool
-   *
-   * @param object the object to destroy
-   */
-  void destroy(V object);
-
+	
+	/**
+	 * Creates the defined Object V based on the current Pool Key.
+	 *
+	 * @param key the key being requested
+	 *
+	 * @return the Object to be inserted into the Pool
+	 */
+	V create(PoolKey<K> key);
+	
+	/**
+	 * Reinitialize an instance to be returned to the borrower
+	 *
+	 * @param object the object being borrowed
+	 */
+	void activate(V object);
+	
+	/**
+	 * Uninitialize an instance which has been released back to the pool
+	 *
+	 * @param object the object to which has just beel released
+	 */
+	void passivate(V object);
+	
+	/**
+	 * Destroy an instance no longer needed by the pool
+	 *
+	 * @param object the object to destroy
+	 */
+	void destroy(V object);
+	
 }

--- a/src/main/java/org/pacesys/kbop/IPooledObject.java
+++ b/src/main/java/org/pacesys/kbop/IPooledObject.java
@@ -1,46 +1,47 @@
 package org.pacesys.kbop;
 
 /**
- * A Object Pool Entry which wraps the underlying borrowed Object as V.  
- * 
+ * A Object Pool Entry which wraps the underlying borrowed Object as V.
+ *
  * @param <V> the value type
  * @param <K> the pool key type
  */
 public interface IPooledObject<V, K> {
-
-  /**
-   * The borrowed object this Pooled Object is associated with
-   *
-   * @return the actual borrowed Object V
-   */
-  V get();
-
-  /**
-   * The Date/Time in milliseconds when this Object was created and initially inserted into the Pool
-   *
-   * @return the created
-   */
-  long getCreated();
-
-  /**
-   * Releases this Object back into the Pool allowing others to access it
-   */
-  void release();
-
-  /**
-   * Releases the object from the pool and removes it.  If the key associated with this object no longer has available object(s)
-   * to borrow against depending on the Pool Configuration then a new object will be created on the next request.
-   */
-  void invalidate();
-
-  /**
-   * The Key which is associated with this Pool Object
-   * @return the Pool Key
-   */
-  PoolKey<K> getKey();
-  
-  /**
-   * @return the user inner key
-   */
-  K getUserKey();
+	
+	/**
+	 * The borrowed object this Pooled Object is associated with
+	 *
+	 * @return the actual borrowed Object V
+	 */
+	V get();
+	
+	/**
+	 * The Date/Time in milliseconds when this Object was created and initially inserted into the Pool
+	 *
+	 * @return the created
+	 */
+	long getCreated();
+	
+	/**
+	 * Releases this Object back into the Pool allowing others to access it
+	 */
+	void release();
+	
+	/**
+	 * Releases the object from the pool and removes it.  If the key associated with this object no longer has available object(s) to borrow against depending on the Pool Configuration then a new
+	 * object will be created on the next request.
+	 */
+	void invalidate();
+	
+	/**
+	 * The Key which is associated with this Pool Object
+	 *
+	 * @return the Pool Key
+	 */
+	PoolKey<K> getKey();
+	
+	/**
+	 * @return the user inner key
+	 */
+	K getUserKey();
 }

--- a/src/main/java/org/pacesys/kbop/IPooledObject.java
+++ b/src/main/java/org/pacesys/kbop/IPooledObject.java
@@ -4,9 +4,10 @@ package org.pacesys.kbop;
  * A Object Pool Entry which wraps the underlying borrowed Object as V.  
  * 
  * @param <V> the value type
+ * @param <K> the pool key type
  * @author Jeremy Unruh
  */
-public interface IPooledObject<V> {
+public interface IPooledObject<V, K> {
 
   /**
    * The borrowed object this Pooled Object is associated with
@@ -37,11 +38,10 @@ public interface IPooledObject<V> {
    * The Key which is associated with this Pool Object
    * @return the Pool Key
    */
-  <K> PoolKey<K> getKey();
+  PoolKey<K> getKey();
   
   /**
    * @return the user inner key
    */
-  <K> K getUserKey();
-
+  K getUserKey();
 }

--- a/src/main/java/org/pacesys/kbop/IPooledObject.java
+++ b/src/main/java/org/pacesys/kbop/IPooledObject.java
@@ -5,7 +5,6 @@ package org.pacesys.kbop;
  * 
  * @param <V> the value type
  * @param <K> the pool key type
- * @author Jeremy Unruh
  */
 public interface IPooledObject<V, K> {
 

--- a/src/main/java/org/pacesys/kbop/PoolKey.java
+++ b/src/main/java/org/pacesys/kbop/PoolKey.java
@@ -29,7 +29,7 @@ public class PoolKey<K> implements Cloneable, Serializable {
   public static <K> PoolKey<K> lookup(K key) {
 	if (key == null) 
 	  throw new IllegalStateException("Key must not be null");
-	return new PoolKey<K>(key);
+	return new PoolKey<>(key);
   }
 
   /**

--- a/src/main/java/org/pacesys/kbop/PoolKey.java
+++ b/src/main/java/org/pacesys/kbop/PoolKey.java
@@ -6,7 +6,6 @@ import lombok.Value;
  * Key used to point to the Object Pool Entry(s)
  *
  * @param <K> the key type
- * @author Jeremy Unruh
  */
 @Value
 public class PoolKey<K> {

--- a/src/main/java/org/pacesys/kbop/PoolKey.java
+++ b/src/main/java/org/pacesys/kbop/PoolKey.java
@@ -2,8 +2,6 @@ package org.pacesys.kbop;
 
 import lombok.Value;
 
-import java.io.Serializable;
-
 /**
  * Key used to point to the Object Pool Entry(s)
  *
@@ -11,7 +9,6 @@ import java.io.Serializable;
  * @author Jeremy Unruh
  */
 @Value
-public class PoolKey<K> implements Cloneable, Serializable {
-	private static final long serialVersionUID = 4383493776548641532L;
+public class PoolKey<K> {
 	private final K key;
 }

--- a/src/main/java/org/pacesys/kbop/PoolKey.java
+++ b/src/main/java/org/pacesys/kbop/PoolKey.java
@@ -1,76 +1,17 @@
 package org.pacesys.kbop;
 
+import lombok.Value;
+
 import java.io.Serializable;
 
 /**
  * Key used to point to the Object Pool Entry(s)
- * 
+ *
  * @param <K> the key type
  * @author Jeremy Unruh
  */
+@Value
 public class PoolKey<K> implements Cloneable, Serializable {
-
-  private static final long serialVersionUID = 4383493776548641532L;
-  private final K key;
-  private final int hashCode;
-
-  private PoolKey(K key) {
-	this.key = key;
-	this.hashCode = computeHashCode();
-  }
-
-  /**
-   * Creates a new Pool Key wrapping the specified key of type {@code K}
-   *
-   * @param <K> the wrapped inner pool key type
-   * @param key the wrapped key
-   * @return PoolKey
-   */
-  public static <K> PoolKey<K> lookup(K key) {
-	if (key == null) 
-	  throw new IllegalStateException("Key must not be null");
-	return new PoolKey<>(key);
-  }
-
-  /**
-   * @return the inner wrapped pool key
-   */
-  public K get() {
-	return key;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public int hashCode() {
-	return hashCode;
-  }
-
-  private int computeHashCode() {
-	final int prime = 31;
-	int result = 1;
-	result = prime * result + ((key == null) ? 0 : key.hashCode());
-	return result;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean equals(Object obj) {
-	if (this == obj)
-	  return true;
-	if (obj == null)
-	  return false;
-	if (getClass() != obj.getClass())
-	  return false;
-	PoolKey<?> other = (PoolKey<?>) obj;
-	if (key == null) {
-	  if (other.key != null)
-		return false;
-	} else if (!key.equals(other.key))
-	  return false;
-	return true;
-  }
+	private static final long serialVersionUID = 4383493776548641532L;
+	private final K key;
 }

--- a/src/main/java/org/pacesys/kbop/PoolMetrics.java
+++ b/src/main/java/org/pacesys/kbop/PoolMetrics.java
@@ -4,7 +4,6 @@ import lombok.Value;
 import lombok.experimental.NonFinal;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
 
@@ -14,9 +13,7 @@ import java.util.Map;
  * @author Jeremy Unruh
  */
 @NonFinal@Value
-public class PoolMetrics implements Serializable {
-
-	private static final long serialVersionUID = -2325874226714753991L;
+public class PoolMetrics {
 
 	private final int borrowedCount;
 	private final int waitingCount;
@@ -29,7 +26,6 @@ public class PoolMetrics implements Serializable {
 	 */
 	public static class PoolMultiMetrics<K> extends PoolMetrics {
 
-		private static final long serialVersionUID = 5188832983690021017L;
 		private final Map<PoolKey<K>, KeyMetric> keyMetrics;
 
 		public PoolMultiMetrics(int borrowedCount, int waitingCount, int maxObjectsPerKey, Map<PoolKey<K>, KeyMetric> keyMetrics) {
@@ -62,8 +58,7 @@ public class PoolMetrics implements Serializable {
 	}
 
 	@Value
-	public static class KeyMetric implements Serializable {
-		private static final long serialVersionUID = 916100737260197225L;
+	public static class KeyMetric {
 		private final int allocationSize;
 		private final int borrowedCount;
 		private final int waitingCount;

--- a/src/main/java/org/pacesys/kbop/PoolMetrics.java
+++ b/src/main/java/org/pacesys/kbop/PoolMetrics.java
@@ -1,10 +1,10 @@
 package org.pacesys.kbop;
 
+import lombok.EqualsAndHashCode;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Date;
 import java.util.Map;
 
 /**
@@ -18,11 +18,11 @@ public class PoolMetrics {
 	private final int waitingCount;
 	private final int maxObjectsPerKey;
 	private final int keyCount;
-	private final Date collectedDate = new Date();
 	
 	/**
 	 * Extends Pool Metrics providing extended Per-Key metrics
 	 */
+	@EqualsAndHashCode(callSuper = true)
 	public static class PoolMultiMetrics<K> extends PoolMetrics {
 		
 		private final Map<PoolKey<K>, KeyMetric> keyMetrics;

--- a/src/main/java/org/pacesys/kbop/PoolMetrics.java
+++ b/src/main/java/org/pacesys/kbop/PoolMetrics.java
@@ -1,5 +1,7 @@
 package org.pacesys.kbop;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
@@ -110,6 +112,7 @@ public class PoolMetrics<K> implements Serializable {
 		 * @return Key Metric if this is a Multi Object Pool and the Key exists otherwise null
 		 * @see #hasMetricsForKey(PoolKey)
 		 */
+		@Nullable
 		public KeyMetric getKeyMetrics(K key) {
 			if (keyMetrics != null)
 				return keyMetrics.get(PoolKey.lookup(key));

--- a/src/main/java/org/pacesys/kbop/PoolMetrics.java
+++ b/src/main/java/org/pacesys/kbop/PoolMetrics.java
@@ -10,9 +10,10 @@ import java.util.Map;
 /**
  * Provides a metrics snapshot for a Pool
  */
-@NonFinal@Value
+@NonFinal
+@Value
 public class PoolMetrics {
-
+	
 	private final int borrowedCount;
 	private final int waitingCount;
 	private final int maxObjectsPerKey;
@@ -23,17 +24,17 @@ public class PoolMetrics {
 	 * Extends Pool Metrics providing extended Per-Key metrics
 	 */
 	public static class PoolMultiMetrics<K> extends PoolMetrics {
-
+		
 		private final Map<PoolKey<K>, KeyMetric> keyMetrics;
-
+		
 		public PoolMultiMetrics(int borrowedCount, int waitingCount, int maxObjectsPerKey, Map<PoolKey<K>, KeyMetric> keyMetrics) {
 			super(borrowedCount, waitingCount, maxObjectsPerKey, keyMetrics.size());
 			this.keyMetrics = keyMetrics;
 		}
-
+		
 		/**
-		 * Only Object Pools with a maxItemsPerKey > 1 will populate Key Metrics.  Single Key to Object Pools do not populate this call
-		 * so null is returned.
+		 * Only Object Pools with a maxItemsPerKey > 1 will populate Key Metrics.  Single Key to Object Pools do not populate this call so null is returned.
+		 *
 		 * @return Key Metric if this is a Multi Object Pool and the Key exists otherwise null
 		 * @see #hasMetricsForKey(Object)
 		 */
@@ -43,18 +44,20 @@ public class PoolMetrics {
 				return keyMetrics.get(new PoolKey<>(key));
 			return null;
 		}
-
+		
 		/**
 		 * Determines if metrics have been populated for the specified Key
+		 *
 		 * @param key the Pool Key to query metrics for
+		 *
 		 * @return true if metrics are available for the given {@code key}
 		 */
 		public boolean hasMetricsForKey(K key) {
 			return keyMetrics != null && keyMetrics.containsKey(new PoolKey<>(key));
 		}
-
+		
 	}
-
+	
 	@Value
 	public static class KeyMetric {
 		private final int allocationSize;

--- a/src/main/java/org/pacesys/kbop/PoolMetrics.java
+++ b/src/main/java/org/pacesys/kbop/PoolMetrics.java
@@ -1,5 +1,7 @@
 package org.pacesys.kbop;
 
+import lombok.Value;
+import lombok.experimental.NonFinal;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
@@ -11,7 +13,8 @@ import java.util.Map;
  * 
  * @author Jeremy Unruh
  */
-public class PoolMetrics<K> implements Serializable {
+@NonFinal@Value
+public class PoolMetrics implements Serializable {
 
 	private static final long serialVersionUID = -2325874226714753991L;
 
@@ -19,84 +22,12 @@ public class PoolMetrics<K> implements Serializable {
 	private final int waitingCount;
 	private final int maxObjectsPerKey;
 	private final int keyCount;
-	private final Date collectedDate;
-
-	/**
-	 * Instantiates a new pool metrics.
-	 *
-	 * @param borrowedCount the borrowed count
-	 * @param waitingCount the waiting count
-	 * @param maxObjectsPerKey the max objects per key
-	 * @param keyCount the key count
-	 */
-	public PoolMetrics(int borrowedCount, int waitingCount, int maxObjectsPerKey, int keyCount) {
-		super();
-		this.borrowedCount = borrowedCount;
-		this.waitingCount = waitingCount;
-		this.maxObjectsPerKey = maxObjectsPerKey;
-		this.keyCount = keyCount;
-		this.collectedDate = new Date();
-	}
-
-	/**
-	 * Gets the borrowed count.
-	 *
-	 * @return the borrowed count
-	 */
-	public int getBorrowedCount() {
-		return this.borrowedCount;
-	}
-
-	/**
-	 * Gets the waiting count.
-	 *
-	 * @return the waiting count
-	 */
-	public int getWaitingCount() {
-		return this.waitingCount;
-	}
-
-	/**
-	 * Gets the max objects per key.
-	 *
-	 * @return the max objects per key
-	 */
-	public int getMaxObjectsPerKey() {
-		return this.maxObjectsPerKey;
-	}
-
-	/**
-	 * Gets the key count.
-	 *
-	 * @return the key count
-	 */
-	public int getKeyCount() {
-		return this.keyCount;
-	}
-
-	/**
-	 * The date the metrics were collected
-	 * @return Metric collection date
-	 */
-	public Date getCollectedDate() {
-		return this.collectedDate;
-	}
-
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String toString() {
-		return "PoolMetrics [collectedDate=" + this.collectedDate + ", borrowedCount=" + this.borrowedCount
-				+ ", waitingCount=" + this.waitingCount + ", keyCount=" + this.keyCount + ", maxObjectsPerKey="
-				+ this.maxObjectsPerKey + "]";
-	}
-
+	private final Date collectedDate = new Date();
+	
 	/**
 	 * Extends Pool Metrics providing extended Per-Key metrics
 	 */
-	public static class PoolMultiMetrics<K> extends PoolMetrics<K> {
+	public static class PoolMultiMetrics<K> extends PoolMetrics {
 
 		private static final long serialVersionUID = 5188832983690021017L;
 		private final Map<PoolKey<K>, KeyMetric> keyMetrics;
@@ -115,7 +46,7 @@ public class PoolMetrics<K> implements Serializable {
 		@Nullable
 		public KeyMetric getKeyMetrics(K key) {
 			if (keyMetrics != null)
-				return keyMetrics.get(PoolKey.lookup(key));
+				return keyMetrics.get(new PoolKey<>(key));
 			return null;
 		}
 
@@ -125,43 +56,16 @@ public class PoolMetrics<K> implements Serializable {
 		 * @return true if metrics are available for the given {@code key}
 		 */
 		public boolean hasMetricsForKey(K key) {
-			return keyMetrics != null && keyMetrics.containsKey(PoolKey.lookup(key));
+			return keyMetrics != null && keyMetrics.containsKey(new PoolKey<>(key));
 		}
 
 	}
 
+	@Value
 	public static class KeyMetric implements Serializable {
-
 		private static final long serialVersionUID = 916100737260197225L;
 		private final int allocationSize;
 		private final int borrowedCount;
 		private final int waitingCount;
-
-		public KeyMetric(int allocationSize, int borrowedCount, int waitingCount) {
-			super();
-			this.allocationSize = allocationSize;
-			this.borrowedCount = borrowedCount;
-			this.waitingCount = waitingCount;
-		}
-
-		public int getAllocationSize() {
-			return this.allocationSize;
-		}
-
-		public int getBorrowedCount() {
-			return this.borrowedCount;
-		}
-
-		public int getWaitingCount() {
-			return this.waitingCount;
-		}
-
-		@Override
-		public String toString() {
-			return "KeyMetric [allocationSize=" + this.allocationSize + ", borrowedCount=" + this.borrowedCount
-					+ ", waitingCount=" + this.waitingCount + "]";
-		}
-
 	}
-
 }

--- a/src/main/java/org/pacesys/kbop/PoolMetrics.java
+++ b/src/main/java/org/pacesys/kbop/PoolMetrics.java
@@ -15,11 +15,11 @@ public class PoolMetrics<K> implements Serializable {
 
 	private static final long serialVersionUID = -2325874226714753991L;
 
-	private int borrowedCount;
-	private int waitingCount;
-	private int maxObjectsPerKey;
-	private int keyCount;
-	private Date collectedDate;
+	private final int borrowedCount;
+	private final int waitingCount;
+	private final int maxObjectsPerKey;
+	private final int keyCount;
+	private final Date collectedDate;
 
 	/**
 	 * Instantiates a new pool metrics.
@@ -99,7 +99,7 @@ public class PoolMetrics<K> implements Serializable {
 	public static class PoolMultiMetrics<K> extends PoolMetrics<K> {
 
 		private static final long serialVersionUID = 5188832983690021017L;
-		private Map<PoolKey<K>, KeyMetric> keyMetrics;
+		private final Map<PoolKey<K>, KeyMetric> keyMetrics;
 
 		public PoolMultiMetrics(int borrowedCount, int waitingCount, int maxObjectsPerKey, Map<PoolKey<K>, KeyMetric> keyMetrics) {
 			super(borrowedCount, waitingCount, maxObjectsPerKey, keyMetrics.size());
@@ -110,7 +110,7 @@ public class PoolMetrics<K> implements Serializable {
 		 * Only Object Pools with a maxItemsPerKey > 1 will populate Key Metrics.  Single Key to Object Pools do not populate this call
 		 * so null is returned.
 		 * @return Key Metric if this is a Multi Object Pool and the Key exists otherwise null
-		 * @see #hasMetricsForKey(PoolKey)
+		 * @see #hasMetricsForKey(Object)
 		 */
 		@Nullable
 		public KeyMetric getKeyMetrics(K key) {
@@ -133,9 +133,9 @@ public class PoolMetrics<K> implements Serializable {
 	public static class KeyMetric implements Serializable {
 
 		private static final long serialVersionUID = 916100737260197225L;
-		private int allocationSize;
-		private int borrowedCount;
-		private int waitingCount;
+		private final int allocationSize;
+		private final int borrowedCount;
+		private final int waitingCount;
 
 		public KeyMetric(int allocationSize, int borrowedCount, int waitingCount) {
 			super();

--- a/src/main/java/org/pacesys/kbop/PoolMetrics.java
+++ b/src/main/java/org/pacesys/kbop/PoolMetrics.java
@@ -9,8 +9,6 @@ import java.util.Map;
 
 /**
  * Provides a metrics snapshot for a Pool
- * 
- * @author Jeremy Unruh
  */
 @NonFinal@Value
 public class PoolMetrics {

--- a/src/main/java/org/pacesys/kbop/Pools.java
+++ b/src/main/java/org/pacesys/kbop/Pools.java
@@ -7,25 +7,28 @@ import org.pacesys.kbop.internal.KeyedSingleObjectPool;
  * Static utility methods pertaining to  {@link IKeyedObjectPool} instances
  */
 public class Pools {
-
-  /**
-   * Creates a new Single Key to Object Pool
-   * @param factory the factory which creates new Objects (T) when needed 
-   * @return IKeyedObjectPool
-   */
-  public static <K, T> IKeyedObjectPool.Single<K, T> createPool(IPoolObjectFactory<K, T> factory) {
-	return new KeyedSingleObjectPool<>(factory);
-  }
-
-  /**
-   * Creates a new Single or Multi Object Pool depending on the maxItemsPerKey size.  If the {@code maxItemsPerKey} is > 1
-   * then a Multi Object to Key Pool is created.  
-   * @param factory the factory which creates new Objects (T) when needed 
-   * @param maxItemsPerKey the size of pooled object for a single given key
-   * @return IKeyedObjectPool
-   */
-  public static <K, T> IKeyedObjectPool.Multi<K, T> createMultiPool(IPoolObjectFactory<K, T> factory, int maxItemsPerKey) {
-	  return new KeyedMultiObjectPool<>(factory, maxItemsPerKey);
-
-  }
+	
+	/**
+	 * Creates a new Single Key to Object Pool
+	 *
+	 * @param factory the factory which creates new Objects (T) when needed
+	 *
+	 * @return IKeyedObjectPool
+	 */
+	public static <K, T> IKeyedObjectPool.Single<K, T> createPool(IPoolObjectFactory<K, T> factory) {
+		return new KeyedSingleObjectPool<>(factory);
+	}
+	
+	/**
+	 * Creates a new Single or Multi Object Pool depending on the maxItemsPerKey size.  If the {@code maxItemsPerKey} is > 1 then a Multi Object to Key Pool is created.
+	 *
+	 * @param factory        the factory which creates new Objects (T) when needed
+	 * @param maxItemsPerKey the size of pooled object for a single given key
+	 *
+	 * @return IKeyedObjectPool
+	 */
+	public static <K, T> IKeyedObjectPool.Multi<K, T> createMultiPool(IPoolObjectFactory<K, T> factory, int maxItemsPerKey) {
+		return new KeyedMultiObjectPool<>(factory, maxItemsPerKey);
+		
+	}
 }

--- a/src/main/java/org/pacesys/kbop/Pools.java
+++ b/src/main/java/org/pacesys/kbop/Pools.java
@@ -5,8 +5,6 @@ import org.pacesys.kbop.internal.KeyedSingleObjectPool;
 
 /**
  * Static utility methods pertaining to  {@link IKeyedObjectPool} instances
- * 
- * @author Jeremy Unruh
  */
 public class Pools {
 

--- a/src/main/java/org/pacesys/kbop/Pools.java
+++ b/src/main/java/org/pacesys/kbop/Pools.java
@@ -16,7 +16,7 @@ public class Pools {
    * @return IKeyedObjectPool
    */
   public static <K, T> IKeyedObjectPool.Single<K, T> createPool(IPoolObjectFactory<K, T> factory) {
-	return new KeyedSingleObjectPool<K, T>(factory);
+	return new KeyedSingleObjectPool<>(factory);
   }
 
   /**
@@ -27,7 +27,7 @@ public class Pools {
    * @return IKeyedObjectPool
    */
   public static <K, T> IKeyedObjectPool.Multi<K, T> createMultiPool(IPoolObjectFactory<K, T> factory, int maxItemsPerKey) {
-	  return new KeyedMultiObjectPool<K, T>(factory, maxItemsPerKey);
+	  return new KeyedMultiObjectPool<>(factory, maxItemsPerKey);
 
   }
 }

--- a/src/main/java/org/pacesys/kbop/internal/AbstractKeyedObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/AbstractKeyedObjectPool.java
@@ -178,6 +178,7 @@ public abstract class AbstractKeyedObjectPool<K, V, E extends PoolableObject<V, 
 	 *
 	 * @return Entry if available
 	 */
+	@Nullable
 	E createOrAttemptToBorrow(final PoolKey<K> key) {
 		E entry;
 		if (!pool.containsKey(key)) {

--- a/src/main/java/org/pacesys/kbop/internal/AbstractKeyedObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/AbstractKeyedObjectPool.java
@@ -24,7 +24,6 @@ import java.util.concurrent.locks.ReentrantLock;
  * @param <K> The internal pool key type
  * @param <V> the object to Borrow
  * @param <E> the pool object holder containing the pooled object
- * @author Jeremy Unruh
  */
 public abstract class AbstractKeyedObjectPool<K, V, E extends PoolableObject<V, K>> implements IKeyedObjectPool<K, V> {
 

--- a/src/main/java/org/pacesys/kbop/internal/AbstractKeyedObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/AbstractKeyedObjectPool.java
@@ -39,7 +39,7 @@ public abstract class AbstractKeyedObjectPool<K, V, E extends PoolableObject<V, 
 	/**
 	 * Instantiates a new abstract keyed object pool.
 	 */
-	public AbstractKeyedObjectPool(IPoolObjectFactory<K, V> factory) {
+	AbstractKeyedObjectPool(IPoolObjectFactory<K, V> factory) {
 		this.lock = new ReentrantLock();
 		this.waiting = new LinkedList<>();
 		this.borrowed = new HashSet<>();
@@ -70,7 +70,7 @@ public abstract class AbstractKeyedObjectPool<K, V, E extends PoolableObject<V, 
 	 */
 	@Override
 	public IPooledObject<V, K> borrow(K key) throws Exception {
-		return createFuture(PoolKey.lookup(key)).get();
+		return createFuture(new PoolKey<>(key)).get();
 	}
 
 	/**
@@ -78,7 +78,7 @@ public abstract class AbstractKeyedObjectPool<K, V, E extends PoolableObject<V, 
 	 */
 	@Override
 	public IPooledObject<V, K> borrow(K key, long timeout, TimeUnit unit) throws Exception {
-		return createFuture(PoolKey.lookup(key)).get(timeout, unit);
+		return createFuture(new PoolKey<>(key)).get(timeout, unit);
 	}
 
 	/**

--- a/src/main/java/org/pacesys/kbop/internal/AbstractKeyedObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/AbstractKeyedObjectPool.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.jetbrains.annotations.Nullable;
 import org.pacesys.kbop.IKeyedObjectPool;
 import org.pacesys.kbop.IPoolObjectFactory;
 import org.pacesys.kbop.IPooledObject;
@@ -214,7 +215,7 @@ public abstract class AbstractKeyedObjectPool<K, V, E extends PoolableObject<V>>
 	 * @return true if
 	 * @throws InterruptedException the interrupted exception
 	 */
-	protected boolean await(final PoolWaitFuture<E> future, final PoolKey<K> key, Date deadline) throws InterruptedException {
+	protected boolean await(final PoolWaitFuture<E> future, final PoolKey<K> key, @Nullable Date deadline) throws InterruptedException {
 		try
 		{
 			waiting.add(future);

--- a/src/main/java/org/pacesys/kbop/internal/KeyedMultiObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/KeyedMultiObjectPool.java
@@ -4,6 +4,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jetbrains.annotations.Nullable;
 import org.pacesys.kbop.IKeyedObjectPool;
 import org.pacesys.kbop.IPoolObjectFactory;
 import org.pacesys.kbop.IPooledObject;
@@ -80,6 +81,7 @@ public class KeyedMultiObjectPool<K, V> extends AbstractKeyedObjectPool<K, V, Po
 
 
 	@Override
+	@Nullable
 	protected PoolableObject<V> createOrAttemptToBorrow(PoolKey<K> key) {
 
 		PoolableObjects<V> pobjs = objectPool(key);
@@ -104,7 +106,7 @@ public class KeyedMultiObjectPool<K, V> extends AbstractKeyedObjectPool<K, V, Po
 	 * {@inheritDoc}
 	 */
 	@Override
-	protected boolean await(final PoolWaitFuture<PoolableObject<V>> future, final PoolKey<K> key, Date deadline) throws InterruptedException {
+	protected boolean await(final PoolWaitFuture<PoolableObject<V>> future, final PoolKey<K> key, @Nullable Date deadline) throws InterruptedException {
 		PoolableObjects<V> pobjs = objectPool(key);
 		try
 		{

--- a/src/main/java/org/pacesys/kbop/internal/KeyedMultiObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/KeyedMultiObjectPool.java
@@ -17,7 +17,6 @@ import org.pacesys.kbop.PoolMetrics.PoolMultiMetrics;
  * 
  * @param <K> the key type
  * @param <V> the value type
- * @author Jeremy Unruh
  */
 public class KeyedMultiObjectPool<K, V> extends AbstractKeyedObjectPool<K, V, PoolableObject<V, K>> implements IKeyedObjectPool.Multi<K, V> {
 

--- a/src/main/java/org/pacesys/kbop/internal/KeyedMultiObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/KeyedMultiObjectPool.java
@@ -35,7 +35,8 @@ public class KeyedMultiObjectPool<K, V> extends AbstractKeyedObjectPool<K, V, Po
 	
 	protected void release(IPooledObject<V, K> borrowedObject, boolean reusable) {
 		lock.lock();
-		if (borrowed.remove(borrowedObject))
+		final PoolableObject<V, K> borrowedVK = (PoolableObject<V, K>) borrowedObject;
+		if (borrowed.remove(borrowedVK))
 		{
 			PoolableObjects<V, K> pos = objectPool(borrowedObject.getKey(), Boolean.FALSE);
 			if (pos != null) {

--- a/src/main/java/org/pacesys/kbop/internal/KeyedSingleObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/KeyedSingleObjectPool.java
@@ -7,16 +7,16 @@ import org.pacesys.kbop.PoolMetrics;
 
 /**
  * Thread-Safe Single Key to Object based Blocking Pool.
- * 
+ *
  * @param <K> the key type
  * @param <V> the pooled object
  */
-public class KeyedSingleObjectPool<K,V> extends AbstractKeyedObjectPool<K, V, PoolableObject<V, K>> implements IKeyedObjectPool.Single<K, V> {
-
+public class KeyedSingleObjectPool<K, V> extends AbstractKeyedObjectPool<K, V, PoolableObject<V, K>> implements IKeyedObjectPool.Single<K, V> {
+	
 	public KeyedSingleObjectPool(IPoolObjectFactory<K, V> factory) {
 		super(factory);
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */
@@ -24,7 +24,7 @@ public class KeyedSingleObjectPool<K,V> extends AbstractKeyedObjectPool<K, V, Po
 	protected PoolableObject<V, K> create(PoolKey<K> key) {
 		return new PoolableObject<>(factory.create(key));
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */
@@ -32,11 +32,12 @@ public class KeyedSingleObjectPool<K,V> extends AbstractKeyedObjectPool<K, V, Po
 	public PoolMetrics getPoolMetrics() {
 		return new PoolMetrics(this.borrowed.size(), this.waiting.size(), 1, pool.keySet().size());
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	protected void onShutDown() { }
-
+	protected void onShutDown() {
+	}
+	
 }

--- a/src/main/java/org/pacesys/kbop/internal/KeyedSingleObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/KeyedSingleObjectPool.java
@@ -31,8 +31,8 @@ public class KeyedSingleObjectPool<K,V> extends AbstractKeyedObjectPool<K, V, Po
 	 * {@inheritDoc}
 	 */
 	@Override
-	public PoolMetrics<K> getPoolMetrics() {
-		return new PoolMetrics<>(this.borrowed.size(), this.waiting.size(), 1, pool.keySet().size());
+	public PoolMetrics getPoolMetrics() {
+		return new PoolMetrics(this.borrowed.size(), this.waiting.size(), 1, pool.keySet().size());
 	}
 
 	/**

--- a/src/main/java/org/pacesys/kbop/internal/KeyedSingleObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/KeyedSingleObjectPool.java
@@ -10,8 +10,6 @@ import org.pacesys.kbop.PoolMetrics;
  * 
  * @param <K> the key type
  * @param <V> the pooled object
- * 
- * @author Jeremy Unruh
  */
 public class KeyedSingleObjectPool<K,V> extends AbstractKeyedObjectPool<K, V, PoolableObject<V, K>> implements IKeyedObjectPool.Single<K, V> {
 

--- a/src/main/java/org/pacesys/kbop/internal/KeyedSingleObjectPool.java
+++ b/src/main/java/org/pacesys/kbop/internal/KeyedSingleObjectPool.java
@@ -13,7 +13,7 @@ import org.pacesys.kbop.PoolMetrics;
  * 
  * @author Jeremy Unruh
  */
-public class KeyedSingleObjectPool<K,V> extends AbstractKeyedObjectPool<K, V, PoolableObject<V>> implements IKeyedObjectPool.Single<K, V> {
+public class KeyedSingleObjectPool<K,V> extends AbstractKeyedObjectPool<K, V, PoolableObject<V, K>> implements IKeyedObjectPool.Single<K, V> {
 
 	public KeyedSingleObjectPool(IPoolObjectFactory<K, V> factory) {
 		super(factory);
@@ -23,8 +23,8 @@ public class KeyedSingleObjectPool<K,V> extends AbstractKeyedObjectPool<K, V, Po
 	 * {@inheritDoc}
 	 */
 	@Override
-	protected PoolableObject<V> create(PoolKey<K> key) {
-		return new PoolableObject<V>(factory.create(key));
+	protected PoolableObject<V, K> create(PoolKey<K> key) {
+		return new PoolableObject<>(factory.create(key));
 	}
 
 	/**
@@ -32,7 +32,7 @@ public class KeyedSingleObjectPool<K,V> extends AbstractKeyedObjectPool<K, V, Po
 	 */
 	@Override
 	public PoolMetrics<K> getPoolMetrics() {
-		return new PoolMetrics<K>(this.borrowed.size(), this.waiting.size(), 1, pool.keySet().size());
+		return new PoolMetrics<>(this.borrowed.size(), this.waiting.size(), 1, pool.keySet().size());
 	}
 
 	/**

--- a/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
@@ -15,7 +15,6 @@ import java.util.concurrent.locks.Lock;
  * A future which waits until the Pooled Object is available or times out
  * 
  * @param <T> the generic type
- * @author Jeremy Unruh
  */
 public abstract class PoolWaitFuture<T> implements Future<T> {
 

--- a/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
@@ -1,8 +1,8 @@
 package org.pacesys.kbop.internal;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -88,17 +88,16 @@ public abstract class PoolWaitFuture<T> implements Future<T> {
    * @param timeout the timeout
    * @param unit the unit
    * @return the entry
-   * @throws IOException Signals that an I/O exception has occurred.
    * @throws InterruptedException the interrupted exception
    * @throws TimeoutException the timeout exception
    */
-  protected abstract T getPoolObject(long timeout, TimeUnit unit) throws IOException, InterruptedException, TimeoutException;
+  protected abstract T getPoolObject(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException;
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+  public T get(long timeout, @NotNull TimeUnit unit) throws InterruptedException, TimeoutException {
 	this.lock.lock();
 	try {
 	  if (this.completed) {
@@ -107,10 +106,6 @@ public abstract class PoolWaitFuture<T> implements Future<T> {
 	  this.result = getPoolObject(timeout, unit);
 	  this.completed = true;
 	  return result;
-	} catch (IOException ex) {
-	  this.completed = true;
-	  this.result = null;
-	  throw new ExecutionException(ex);
 	} finally {
 	  this.lock.unlock();
 	}
@@ -129,7 +124,7 @@ public abstract class PoolWaitFuture<T> implements Future<T> {
 	  if (this.cancelled) {
 		throw new InterruptedException("Operation interrupted");
 	  }
-	  boolean success = false;
+	  boolean success;
 	  if (deadline != null) {
 		success = this.condition.awaitUntil(deadline);
 	  } else {

--- a/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
@@ -29,7 +29,7 @@ public abstract class PoolWaitFuture<T> implements Future<T> {
 	 *
 	 * @param lock the lock
 	 */
-	public PoolWaitFuture(Lock lock) {
+	PoolWaitFuture(Lock lock) {
 		this.lock = lock;
 		this.condition = lock.newCondition();
 	}
@@ -119,7 +119,7 @@ public abstract class PoolWaitFuture<T> implements Future<T> {
 	 * @return true, if successful
 	 * @throws InterruptedException the interrupted exception
 	 */
-	public boolean await(@Nullable final Date deadline) throws InterruptedException {
+	boolean await(@Nullable final Date deadline) throws InterruptedException {
 		this.lock.lock();
 		try {
 			if (this.cancelled) {
@@ -145,7 +145,7 @@ public abstract class PoolWaitFuture<T> implements Future<T> {
 	/**
 	 * Wakes up the current listener
 	 */
-	public void wakeup() {
+	void wakeup() {
 		this.lock.lock();
 		try {
 			this.condition.signalAll();

--- a/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
@@ -1,5 +1,7 @@
 package org.pacesys.kbop.internal;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
@@ -121,7 +123,7 @@ public abstract class PoolWaitFuture<T> implements Future<T> {
    * @return true, if successful
    * @throws InterruptedException the interrupted exception
    */
-  public boolean await(final Date deadline) throws InterruptedException {
+  public boolean await(@Nullable final Date deadline) throws InterruptedException {
 	this.lock.lock();
 	try {
 	  if (this.cancelled) {

--- a/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
@@ -152,6 +152,4 @@ public abstract class PoolWaitFuture<T> implements Future<T> {
 	  this.lock.unlock();
 	}
   }
-
-
 }

--- a/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolWaitFuture.java
@@ -13,142 +13,144 @@ import java.util.concurrent.locks.Lock;
 
 /**
  * A future which waits until the Pooled Object is available or times out
- * 
+ *
  * @param <T> the generic type
  */
 public abstract class PoolWaitFuture<T> implements Future<T> {
-
-  private final Lock lock;
-  private final Condition condition;
-  private volatile boolean cancelled;
-  private volatile boolean completed;
-  private T result;
-
-  /**
-   * Instantiates a new pool wait future.
-   *
-   * @param lock the lock
-   */
-  public PoolWaitFuture(Lock lock) {
-	this.lock = lock;
-	this.condition = lock.newCondition();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean cancel(boolean mayInterruptIfRunning) {
-	this.lock.lock();
-	try {
-	  if (this.completed) {
-		return false;
-	  }
-	  this.completed = true;
-	  this.cancelled = true;
-	  this.condition.signalAll();
-	  return true;
-	} finally {
-	  this.lock.unlock();
+	
+	private final Lock lock;
+	private final Condition condition;
+	private volatile boolean cancelled;
+	private volatile boolean completed;
+	private T result;
+	
+	/**
+	 * Instantiates a new pool wait future.
+	 *
+	 * @param lock the lock
+	 */
+	public PoolWaitFuture(Lock lock) {
+		this.lock = lock;
+		this.condition = lock.newCondition();
 	}
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean isCancelled() {
-	return this.cancelled;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean isDone() {
-	return this.completed;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public T get() throws InterruptedException, ExecutionException {
-	try {
-	  return get(0, TimeUnit.MILLISECONDS);
-	} catch (TimeoutException ex) {
-	  throw new ExecutionException(ex);
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean cancel(boolean mayInterruptIfRunning) {
+		this.lock.lock();
+		try {
+			if (this.completed) {
+				return false;
+			}
+			this.completed = true;
+			this.cancelled = true;
+			this.condition.signalAll();
+			return true;
+		} finally {
+			this.lock.unlock();
+		}
 	}
-  }
-
-  /**
-   * Attempts to borrow/get the Pool Object from the Pool
-   *
-   * @param timeout the timeout
-   * @param unit the unit
-   * @return the entry
-   * @throws InterruptedException the interrupted exception
-   * @throws TimeoutException the timeout exception
-   */
-  protected abstract T getPoolObject(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException;
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public T get(long timeout, @NotNull TimeUnit unit) throws InterruptedException, TimeoutException {
-	this.lock.lock();
-	try {
-	  if (this.completed) {
-		return this.result;
-	  }
-	  this.result = getPoolObject(timeout, unit);
-	  this.completed = true;
-	  return result;
-	} finally {
-	  this.lock.unlock();
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean isCancelled() {
+		return this.cancelled;
 	}
-  }
-
-  /**
-   * Waits/Blocks until the specified deadline or condition
-   *
-   * @param deadline the deadline
-   * @return true, if successful
-   * @throws InterruptedException the interrupted exception
-   */
-  public boolean await(@Nullable final Date deadline) throws InterruptedException {
-	this.lock.lock();
-	try {
-	  if (this.cancelled) {
-		throw new InterruptedException("Operation interrupted");
-	  }
-	  boolean success;
-	  if (deadline != null) {
-		success = this.condition.awaitUntil(deadline);
-	  } else {
-		this.condition.await();
-		success = true;
-	  }
-	  if (this.cancelled) {
-		throw new InterruptedException("Operation interrupted");
-	  }
-	  return success;
-	} finally {
-	  this.lock.unlock();
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean isDone() {
+		return this.completed;
 	}
-
-  }
-
-  /**
-   * Wakes up the current listener
-   */
-  public void wakeup() {
-	this.lock.lock();
-	try {
-	  this.condition.signalAll();
-	} finally {
-	  this.lock.unlock();
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public T get() throws InterruptedException, ExecutionException {
+		try {
+			return get(0, TimeUnit.MILLISECONDS);
+		} catch (TimeoutException ex) {
+			throw new ExecutionException(ex);
+		}
 	}
-  }
+	
+	/**
+	 * Attempts to borrow/get the Pool Object from the Pool
+	 *
+	 * @param timeout the timeout
+	 * @param unit    the unit
+	 *
+	 * @return the entry
+	 * @throws InterruptedException the interrupted exception
+	 * @throws TimeoutException     the timeout exception
+	 */
+	protected abstract T getPoolObject(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException;
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public T get(long timeout, @NotNull TimeUnit unit) throws InterruptedException, TimeoutException {
+		this.lock.lock();
+		try {
+			if (this.completed) {
+				return this.result;
+			}
+			this.result = getPoolObject(timeout, unit);
+			this.completed = true;
+			return result;
+		} finally {
+			this.lock.unlock();
+		}
+	}
+	
+	/**
+	 * Waits/Blocks until the specified deadline or condition
+	 *
+	 * @param deadline the deadline
+	 *
+	 * @return true, if successful
+	 * @throws InterruptedException the interrupted exception
+	 */
+	public boolean await(@Nullable final Date deadline) throws InterruptedException {
+		this.lock.lock();
+		try {
+			if (this.cancelled) {
+				throw new InterruptedException("Operation interrupted");
+			}
+			boolean success;
+			if (deadline != null) {
+				success = this.condition.awaitUntil(deadline);
+			} else {
+				this.condition.await();
+				success = true;
+			}
+			if (this.cancelled) {
+				throw new InterruptedException("Operation interrupted");
+			}
+			return success;
+		} finally {
+			this.lock.unlock();
+		}
+		
+	}
+	
+	/**
+	 * Wakes up the current listener
+	 */
+	public void wakeup() {
+		this.lock.lock();
+		try {
+			this.condition.signalAll();
+		} finally {
+			this.lock.unlock();
+		}
+	}
 }

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
@@ -1,5 +1,6 @@
 package org.pacesys.kbop.internal;
 
+import org.jetbrains.annotations.Nullable;
 import org.pacesys.kbop.IKeyedObjectPool;
 import org.pacesys.kbop.IPooledObject;
 import org.pacesys.kbop.PoolKey;
@@ -24,7 +25,7 @@ public class PoolableObject<V> implements IPooledObject<V> {
 	 *
 	 * @param object the object
 	 */
-	public PoolableObject(V object) {
+	public PoolableObject(@Nullable V object) {
 		this.object = object;
 		this.created = System.currentTimeMillis();
 	}

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
@@ -7,18 +7,18 @@ import org.pacesys.kbop.PoolKey;
 
 /**
  * Internal Implementation of IPooledObject which holds onto the internal Object V, Key and Pool which created this Object
- * 
+ *
  * @param <V> the value type
  * @param <K> the pool key type
  */
 public class PoolableObject<V, K> implements IPooledObject<V, K> {
-
+	
 	private final long created;
 	private final V object;
 	private PoolKey<K> key;
 	private IKeyedObjectPool<K, V> pool;
 	private Thread owner;
-
+	
 	/**
 	 * Instantiates a new poolable object.
 	 *
@@ -28,13 +28,14 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 		this.object = object;
 		this.created = System.currentTimeMillis();
 	}
-
+	
 	/**
 	 * Initializes this Object when initially created by the Pool for allocation
 	 *
-	 * @param <E> the Entry Type
-	 * @param key The Key which is associated with this Pool Object
+	 * @param <E>  the Entry Type
+	 * @param key  The Key which is associated with this Pool Object
 	 * @param pool the pool creating this allocation
+	 *
 	 * @return Poolable Object
 	 */
 	@SuppressWarnings("unchecked")
@@ -43,11 +44,12 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 		this.pool = pool;
 		return (E) this;
 	}
-
+	
 	/**
 	 * Flags the current thread as the new Owner of this Object
 	 *
 	 * @param <E> the Entry Type
+	 *
 	 * @return PoolableObject for method chaining
 	 */
 	@SuppressWarnings("unchecked")
@@ -55,7 +57,7 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 		this.owner = Thread.currentThread();
 		return (E) this;
 	}
-
+	
 	/**
 	 * Releases the current owning thread from this Object
 	 *
@@ -64,7 +66,7 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	<E extends PoolableObject<V, K>> void releaseOwner() {
 		this.owner = null;
 	}
-
+	
 	/**
 	 * Determines if the current thread is the Owner of this object (current borrower)
 	 *
@@ -73,7 +75,7 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	public boolean isCurrentOwner() {
 		return Thread.currentThread().equals(owner);
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */
@@ -81,7 +83,7 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	public PoolKey<K> getKey() {
 		return key;
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */
@@ -89,21 +91,21 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	public String toString() {
 		return "PoolableObject [created=" + created + ", object=" + object + "]";
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */
 	public V get() {
 		return object;
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */
 	public long getCreated() {
 		return created;
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */
@@ -111,7 +113,7 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	public void release() {
 		pool.release(this);
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */
@@ -119,7 +121,7 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	public void invalidate() {
 		pool.invalidate(this);
 	}
-
+	
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
@@ -10,7 +10,6 @@ import org.pacesys.kbop.PoolKey;
  * 
  * @param <V> the value type
  * @param <K> the pool key type
- * @author Jeremy Unruh
  */
 public class PoolableObject<V, K> implements IPooledObject<V, K> {
 

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
@@ -9,15 +9,16 @@ import org.pacesys.kbop.PoolKey;
  * Internal Implementation of IPooledObject which holds onto the internal Object V, Key and Pool which created this Object
  * 
  * @param <V> the value type
+ * @param <K> the pool key type
  * @author Jeremy Unruh
  */
-public class PoolableObject<V> implements IPooledObject<V> {
+public class PoolableObject<V, K> implements IPooledObject<V, K> {
 
 	private long created;
 	private long expiry;
 	private V object;
-	private PoolKey<?> key;
-	private IKeyedObjectPool<?, V> pool;
+	private PoolKey<K> key;
+	private IKeyedObjectPool<K, V> pool;
 	private Thread owner;
 
 	/**
@@ -33,14 +34,13 @@ public class PoolableObject<V> implements IPooledObject<V> {
 	/**
 	 * Initializes this Object when initially created by the Pool for allocation
 	 *
-	 * @param <K> The Key wrapped Type
 	 * @param <E> the Entry Type
 	 * @param key The Key which is associated with this Pool Object
 	 * @param pool the pool creating this allocation
 	 * @return Poolable Object
 	 */
 	@SuppressWarnings("unchecked")
-	<K, E extends PoolableObject<V>> E initialize(PoolKey<K> key, IKeyedObjectPool<?, V> pool) {
+	<E extends PoolableObject<V, K>> E initialize(PoolKey<K> key, IKeyedObjectPool<K, V> pool) {
 		this.key = key;
 		this.pool = pool;
 		return (E) this;
@@ -49,12 +49,11 @@ public class PoolableObject<V> implements IPooledObject<V> {
 	/**
 	 * Flags the current thread as the new Owner of this Object
 	 *
-	 * @param <K> the Key wrapped Type
 	 * @param <E> the Entry Type
 	 * @return PoolableObject for method chaining
 	 */
 	@SuppressWarnings("unchecked")
-	<K, E extends PoolableObject<V>> E flagOwner() {
+	<E extends PoolableObject<V, K>> E flagOwner() {
 		this.owner = Thread.currentThread();
 		return (E) this;
 	}
@@ -62,12 +61,11 @@ public class PoolableObject<V> implements IPooledObject<V> {
 	/**
 	 * Releases the current owning thread from this Object
 	 *
-	 * @param <K> the Key wrapped Type
 	 * @param <E> the Entry type
 	 * @return PoolableObject for method chaining
 	 */
 	@SuppressWarnings("unchecked")
-	<K, E extends PoolableObject<V>> E releaseOwner() {
+	<E extends PoolableObject<V, K>> E releaseOwner() {
 		this.owner = null;
 		return (E) this;
 	}
@@ -84,10 +82,9 @@ public class PoolableObject<V> implements IPooledObject<V> {
 	/**
 	 * {@inheritDoc}
 	 */
-	@SuppressWarnings("unchecked")
 	@Override
-	public <K> PoolKey<K> getKey() {
-		return (PoolKey<K>) key;
+	public PoolKey<K> getKey() {
+		return key;
 	}
 
 	/**
@@ -149,10 +146,8 @@ public class PoolableObject<V> implements IPooledObject<V> {
 	/**
 	 * {@inheritDoc}
 	 */
-	@SuppressWarnings("unchecked")
 	@Override
-	public <K> K getUserKey() {
-		return (K) getKey().get();
+	public K getUserKey() {
+		return getKey().get();
 	}
-
 }

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
@@ -126,6 +126,6 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	 */
 	@Override
 	public K getUserKey() {
-		return getKey().get();
+		return getKey().getKey();
 	}
 }

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
@@ -14,9 +14,8 @@ import org.pacesys.kbop.PoolKey;
  */
 public class PoolableObject<V, K> implements IPooledObject<V, K> {
 
-	private long created;
-	private long expiry;
-	private V object;
+	private final long created;
+	private final V object;
 	private PoolKey<K> key;
 	private IKeyedObjectPool<K, V> pool;
 	private Thread owner;
@@ -62,12 +61,9 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	 * Releases the current owning thread from this Object
 	 *
 	 * @param <E> the Entry type
-	 * @return PoolableObject for method chaining
 	 */
-	@SuppressWarnings("unchecked")
-	<E extends PoolableObject<V, K>> E releaseOwner() {
+	<E extends PoolableObject<V, K>> void releaseOwner() {
 		this.owner = null;
-		return (E) this;
 	}
 
 	/**
@@ -92,8 +88,7 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	 */
 	@Override
 	public String toString() {
-		return "PoolableObject [created=" + created + ", expiry=" + expiry
-				+ ", object=" + object + "]";
+		return "PoolableObject [created=" + created + ", object=" + object + "]";
 	}
 
 	/**
@@ -101,23 +96,6 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	 */
 	public V get() {
 		return object;
-	}
-
-	/**
-	 * Determines if this Object has expired
-	 *
-	 * @param now time to compare against
-	 * @return true, if is expired
-	 */
-	public boolean isExpired(long now) {
-		return now >= expiry;
-	}
-
-	/**
-	 * @return the expiry time for this Object
-	 */
-	public long getExpiry() {
-		return expiry;
 	}
 
 	/**

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
@@ -24,7 +24,7 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	 *
 	 * @param object the object
 	 */
-	public PoolableObject(@Nullable V object) {
+	PoolableObject(@Nullable V object) {
 		this.object = object;
 		this.created = System.currentTimeMillis();
 	}
@@ -70,7 +70,7 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	 *
 	 * @return true, if current owner
 	 */
-	public boolean isCurrentOwner() {
+	boolean isCurrentOwner() {
 		return Thread.currentThread().equals(owner);
 	}
 	

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObject.java
@@ -60,10 +60,8 @@ public class PoolableObject<V, K> implements IPooledObject<V, K> {
 	
 	/**
 	 * Releases the current owning thread from this Object
-	 *
-	 * @param <E> the Entry type
 	 */
-	<E extends PoolableObject<V, K>> void releaseOwner() {
+	void releaseOwner() {
 		this.owner = null;
 	}
 	

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
@@ -14,11 +14,11 @@ import org.pacesys.kbop.IPooledObject;
  * @param <K> The pool key type
  * @author Jeremy Unruh
  */
-public class PoolableObjects<V, K> extends PoolableObject<V, K> {
+class PoolableObjects<V, K> extends PoolableObject<V, K> {
 
-	protected final Set<PoolableObject<V, K>> borrowed;
-	protected final LinkedList<PoolableObject<V, K>> available;
-	protected final LinkedList<PoolWaitFuture<PoolableObject<V, K>>> waiting;
+	final Set<PoolableObject<V, K>> borrowed;
+	private final LinkedList<PoolableObject<V, K>> available;
+	final LinkedList<PoolWaitFuture<PoolableObject<V, K>>> waiting;
 
 	/**
 	 * Instantiates a new poolable objects.
@@ -125,6 +125,7 @@ public class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	void shutdown() {
 		available.clear();
 		waiting.clear();
-		available.clear();
+		//noinspection RedundantOperationOnEmptyContainer
+		available.clear(); // FIXME is this intentional?
 	}
 }

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
@@ -12,7 +12,6 @@ import org.pacesys.kbop.IPooledObject;
  * 
  * @param <V> Contained Object Type
  * @param <K> The pool key type
- * @author Jeremy Unruh
  */
 class PoolableObjects<V, K> extends PoolableObject<V, K> {
 

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
@@ -22,7 +22,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	/**
 	 * Instantiates a new poolable objects.
 	 */
-	public PoolableObjects() {
+	PoolableObjects() {
 		super(null);
 		this.borrowed = new HashSet<>();
 		this.available = new LinkedList<>();
@@ -35,7 +35,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	 * @param borrowedObject the borrowed object to free
 	 * @param reusable       true if the object can be recycled and used for future allocations
 	 */
-	public void free(IPooledObject<V, K> borrowedObject, boolean reusable) {
+	void free(IPooledObject<V, K> borrowedObject, boolean reusable) {
 		if (borrowedObject == null) return;
 		
 		final PoolableObject<V, K> borrowedVK = (PoolableObject<V, K>) borrowedObject;
@@ -53,7 +53,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	 * @return Poolable Object or null if we couldn't allocate
 	 */
 	@Nullable
-	public PoolableObject<V, K> getFree() {
+	PoolableObject<V, K> getFree() {
 		if (!borrowed.isEmpty()) {
 			for (PoolableObject<V, K> bo : borrowed) {
 				if (bo.isCurrentOwner())
@@ -75,7 +75,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	 *
 	 * @return the poolable object
 	 */
-	public PoolableObject<V, K> add(final PoolableObject<V, K> entry) {
+	PoolableObject<V, K> add(final PoolableObject<V, K> entry) {
 		borrowed.add(entry);
 		return entry;
 	}
@@ -85,7 +85,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	 *
 	 * @param future the future who is waiting to borrow from this pool
 	 */
-	public void queue(final PoolWaitFuture<PoolableObject<V, K>> future) {
+	void queue(final PoolWaitFuture<PoolableObject<V, K>> future) {
 		if (future == null) return;
 		waiting.add(future);
 	}
@@ -95,7 +95,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	 *
 	 * @param future the future
 	 */
-	public void unqueue(final PoolWaitFuture<PoolableObject<V, K>> future) {
+	void unqueue(final PoolWaitFuture<PoolableObject<V, K>> future) {
 		if (future == null) return;
 		waiting.remove(future);
 	}
@@ -106,7 +106,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	 *
 	 * @return the allocation size
 	 */
-	public int getAllocationSize() {
+	int getAllocationSize() {
 		return available.size() + borrowed.size();
 	}
 	
@@ -115,8 +115,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	 *
 	 * @return the future who has been waiting or null if no waiters
 	 */
-	@Nullable
-	public PoolWaitFuture<PoolableObject<V, K>> nextWaiting() {
+	@Nullable PoolWaitFuture<PoolableObject<V, K>> nextWaiting() {
 		return waiting.poll();
 	}
 	

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
@@ -37,8 +37,9 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	 */
 	public void free(IPooledObject<V, K> borrowedObject, boolean reusable) {
 		if (borrowedObject == null) return;
-
-		if (borrowed.remove(borrowedObject))
+		
+		final PoolableObject<V, K> borrowedVK = (PoolableObject<V, K>) borrowedObject;
+		if (borrowed.remove(borrowedVK))
 		{
 			((PoolableObject<V, K>)borrowedObject).releaseOwner();
 			if (reusable)

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
 
+import org.jetbrains.annotations.Nullable;
 import org.pacesys.kbop.IPooledObject;
 
 /**
@@ -50,6 +51,7 @@ public class PoolableObjects<V> extends PoolableObject<V> {
 	 *
 	 * @return Poolable Object or null if we couldn't allocate
 	 */
+	@Nullable
 	public PoolableObject<V> getFree() {
 		if (!borrowed.isEmpty()) {
 			for (PoolableObject<V> bo : borrowed) {
@@ -111,6 +113,7 @@ public class PoolableObjects<V> extends PoolableObject<V> {
 	 *
 	 * @return the future who has been waiting or null if no waiters
 	 */
+	@Nullable
 	public PoolWaitFuture<PoolableObject<V>> nextWaiting() {
 		return waiting.poll();
 	}

--- a/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
+++ b/src/main/java/org/pacesys/kbop/internal/PoolableObjects.java
@@ -1,24 +1,24 @@
 package org.pacesys.kbop.internal;
 
+import org.jetbrains.annotations.Nullable;
+import org.pacesys.kbop.IPooledObject;
+
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
 
-import org.jetbrains.annotations.Nullable;
-import org.pacesys.kbop.IPooledObject;
-
 /**
  * Defines an Key Object Pool which supports multiple objects available for leasing/acquiring
- * 
+ *
  * @param <V> Contained Object Type
  * @param <K> The pool key type
  */
 class PoolableObjects<V, K> extends PoolableObject<V, K> {
-
+	
 	final Set<PoolableObject<V, K>> borrowed;
 	private final LinkedList<PoolableObject<V, K>> available;
 	final LinkedList<PoolWaitFuture<PoolableObject<V, K>>> waiting;
-
+	
 	/**
 	 * Instantiates a new poolable objects.
 	 */
@@ -28,12 +28,12 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 		this.available = new LinkedList<>();
 		this.waiting = new LinkedList<>();
 	}
-
+	
 	/**
 	 * Frees the borrowed object from the internal Pool
 	 *
 	 * @param borrowedObject the borrowed object to free
-	 * @param reusable true if the object can be recycled and used for future allocations
+	 * @param reusable       true if the object can be recycled and used for future allocations
 	 */
 	public void free(IPooledObject<V, K> borrowedObject, boolean reusable) {
 		if (borrowedObject == null) return;
@@ -41,12 +41,12 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 		final PoolableObject<V, K> borrowedVK = (PoolableObject<V, K>) borrowedObject;
 		if (borrowed.remove(borrowedVK))
 		{
-			((PoolableObject<V, K>)borrowedObject).releaseOwner();
+			((PoolableObject<V, K>) borrowedObject).releaseOwner();
 			if (reusable)
-				available.addFirst((PoolableObject<V, K>)borrowedObject);
+				available.addFirst((PoolableObject<V, K>) borrowedObject);
 		}
 	}
-
+	
 	/**
 	 * Finds an available Poolable Object to borrow
 	 *
@@ -67,18 +67,19 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 		}
 		return null;
 	}
-
+	
 	/**
 	 * Adds the Poolable Object to the borrowed list
 	 *
 	 * @param entry the entry
+	 *
 	 * @return the poolable object
 	 */
 	public PoolableObject<V, K> add(final PoolableObject<V, K> entry) {
 		borrowed.add(entry);
 		return entry;
 	}
-
+	
 	/**
 	 * Queues the {@code future} into the waiting list
 	 *
@@ -88,7 +89,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 		if (future == null) return;
 		waiting.add(future);
 	}
-
+	
 	/**
 	 * Removes the specified {@code future} from the current waiting queue
 	 *
@@ -98,8 +99,8 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 		if (future == null) return;
 		waiting.remove(future);
 	}
-
-
+	
+	
 	/**
 	 * Gets the allocation size.
 	 *
@@ -108,7 +109,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	public int getAllocationSize() {
 		return available.size() + borrowed.size();
 	}
-
+	
 	/**
 	 * Finds the next Future who is waiting to borrow from this pool or null
 	 *
@@ -118,7 +119,7 @@ class PoolableObjects<V, K> extends PoolableObject<V, K> {
 	public PoolWaitFuture<PoolableObject<V, K>> nextWaiting() {
 		return waiting.poll();
 	}
-
+	
 	/**
 	 * Cleans up current resources
 	 */

--- a/src/test/java/org/paceys/kbop/AbstractPoolTest.java
+++ b/src/test/java/org/paceys/kbop/AbstractPoolTest.java
@@ -9,12 +9,12 @@ import org.pacesys.kbop.Pools;
  * Abstract Test Case for Pooled Objects
  */
 public abstract class AbstractPoolTest<P extends IKeyedObjectPool<String, String>> {
-
+	
 	static String POOL_KEY = "TestKey";
 	static String POOL_KEY2 = "TestKey2";
-
+	
 	private P pool;
-
+	
 	@SuppressWarnings("unchecked")
 	public AbstractPoolTest(int maxItemsPerKey) {
 		super();
@@ -22,15 +22,15 @@ public abstract class AbstractPoolTest<P extends IKeyedObjectPool<String, String
 			public String create(PoolKey<String> key) {
 				return "This is a Test : " + key.getKey();
 			}
-
+			
 			@Override
 			public void activate(String object) {
 			}
-
+			
 			@Override
 			public void passivate(String object) {
 			}
-
+			
 			@Override
 			public void destroy(String object) {
 			}
@@ -38,9 +38,9 @@ public abstract class AbstractPoolTest<P extends IKeyedObjectPool<String, String
 		this.pool = (P) ((maxItemsPerKey > 1) ? Pools.createMultiPool(factory,
 				maxItemsPerKey) : Pools.createPool(factory));
 	}
-
+	
 	P pool() {
 		return pool;
 	}
-
+	
 }

--- a/src/test/java/org/paceys/kbop/AbstractPoolTest.java
+++ b/src/test/java/org/paceys/kbop/AbstractPoolTest.java
@@ -8,7 +8,7 @@ import org.pacesys.kbop.Pools;
 /**
  * Abstract Test Case for Pooled Objects
  */
-public abstract class AbstractPoolTest<P extends IKeyedObjectPool<String, String>> {
+abstract class AbstractPoolTest<P extends IKeyedObjectPool<String, String>> {
 	
 	static String POOL_KEY = "TestKey";
 	static String POOL_KEY2 = "TestKey2";
@@ -16,7 +16,7 @@ public abstract class AbstractPoolTest<P extends IKeyedObjectPool<String, String
 	private P pool;
 	
 	@SuppressWarnings("unchecked")
-	public AbstractPoolTest(int maxItemsPerKey) {
+	AbstractPoolTest(int maxItemsPerKey) {
 		super();
 		IPoolObjectFactory<String, String> factory = new IPoolObjectFactory<String, String>() {
 			public String create(PoolKey<String> key) {

--- a/src/test/java/org/paceys/kbop/AbstractPoolTest.java
+++ b/src/test/java/org/paceys/kbop/AbstractPoolTest.java
@@ -7,8 +7,6 @@ import org.pacesys.kbop.Pools;
 
 /**
  * Abstract Test Case for Pooled Objects
- * 
- * @author Jeremy Unruh
  */
 public abstract class AbstractPoolTest<P extends IKeyedObjectPool<String, String>> {
 

--- a/src/test/java/org/paceys/kbop/AbstractPoolTest.java
+++ b/src/test/java/org/paceys/kbop/AbstractPoolTest.java
@@ -22,7 +22,7 @@ public abstract class AbstractPoolTest<P extends IKeyedObjectPool<String, String
 		super();
 		IPoolObjectFactory<String, String> factory = new IPoolObjectFactory<String, String>() {
 			public String create(PoolKey<String> key) {
-				return "This is a Test : " + key.get();
+				return "This is a Test : " + key.getKey();
 			}
 
 			@Override

--- a/src/test/java/org/paceys/kbop/ExecutionContext.java
+++ b/src/test/java/org/paceys/kbop/ExecutionContext.java
@@ -1,128 +1,130 @@
 package org.paceys.kbop;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.pacesys.kbop.IPooledObject;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
- * Concurrent Test Execution Context which allows for various options to be
- * passed through to a Runnable cutting down on Test Boiler Plate code
+ * Concurrent Test Execution Context which allows for various options to be passed through to a Runnable cutting down on Test Boiler Plate code
  */
 public class ExecutionContext {
-
+	
 	public interface PostValidation {
-
+		
 		<V, K> void validate(IPooledObject<V, K> borrowedObject);
 	}
-
-	/** Max time to block waiting for an Object in Milliseconds */
-	public long maxWaitTime = 100;
-
-	/** Time to sleep after a successful borrow in Milliseconds */
-	public long sleepTime = 600;
-
+	
 	/**
-	 * Insure we can re-borrow the previously borrowed object from the current
-	 * thread and that we get back the same instance
+	 * Max time to block waiting for an Object in Milliseconds
+	 */
+	public long maxWaitTime = 100;
+	
+	/**
+	 * Time to sleep after a successful borrow in Milliseconds
+	 */
+	public long sleepTime = 600;
+	
+	/**
+	 * Insure we can re-borrow the previously borrowed object from the current thread and that we get back the same instance
 	 */
 	public boolean verifyCanGetSameInstance = Boolean.TRUE;
-
-	/** The fail if unable to borrow. */
+	
+	/**
+	 * The fail if unable to borrow.
+	 */
 	public boolean failIfUnableToBorrow;
-
+	
 	public boolean reusable = Boolean.TRUE;
-
+	
 	private PostValidation validator;
-
+	
 	private AtomicInteger timeoutCount = new AtomicInteger();
-
+	
 	public static ExecutionContext get() {
 		return new ExecutionContext();
 	}
-
+	
 	/**
-	 * Associates a PostValidation handler to allow extra constraint tests after a
-	 * success object has been borrowed
-	 * 
-	 * @param validator
-	 *          the post validation validator
+	 * Associates a PostValidation handler to allow extra constraint tests after a success object has been borrowed
+	 *
+	 * @param validator the post validation validator
+	 *
 	 * @return the execution context
 	 */
 	public ExecutionContext postValidator(PostValidation validator) {
 		this.validator = validator;
 		return this;
 	}
-
+	
 	/**
 	 * Time to sleep after a successful borrow in Milliseconds
-	 * 
-	 * @param sleepTime
-	 *          the sleep time
+	 *
+	 * @param sleepTime the sleep time
+	 *
 	 * @return the execution context
 	 */
 	public ExecutionContext sleepTime(long sleepTime) {
 		this.sleepTime = sleepTime;
 		return this;
 	}
-
+	
 	/**
 	 * Max time to block waiting for an Object in Milliseconds
-	 * 
-	 * @param maxWaitTime
-	 *          the max wait time
+	 *
+	 * @param maxWaitTime the max wait time
+	 *
 	 * @return the execution context
 	 */
 	public ExecutionContext maxWaitTime(long maxWaitTime) {
 		this.maxWaitTime = maxWaitTime;
 		return this;
 	}
-
+	
 	/**
 	 * Fail if unable to borrow.
-	 * 
-	 * @param failIfUnableToBorrow
-	 *          the fail if unable to borrow
+	 *
+	 * @param failIfUnableToBorrow the fail if unable to borrow
+	 *
 	 * @return the execution context
 	 */
 	public ExecutionContext failIfUnableToBorrow(boolean failIfUnableToBorrow) {
 		this.failIfUnableToBorrow = failIfUnableToBorrow;
 		return this;
 	}
-
+	
 	/**
 	 * If false then the Object will be invalidated back to the Pool vs Released
-	 * 
-	 * @param reusable
-	 *          true to release, false to invalidate
+	 *
+	 * @param reusable true to release, false to invalidate
+	 *
 	 * @return the execution context
 	 */
 	public ExecutionContext reusableAfterAllocation(boolean reusable) {
 		this.reusable = reusable;
 		return this;
 	}
-
+	
 	/**
 	 * @return the number of times we timed out during a threaded execution
 	 */
 	public int getTimeOutCount() {
 		return timeoutCount.get();
 	}
-
+	
 	/**
 	 * Increments the current timeout counter
-	 * 
+	 *
 	 * @return the new timeout
 	 */
 	public int incrementTimeOutCount() {
 		return timeoutCount.incrementAndGet();
 	}
-
+	
 	/**
-	 * Insure we can re-borrow the previously borrowed object from the current
-	 * thread and that we get back the same instance
-	 * 
-	 * @param verifyCanGetSameInstance
-	 *          the verify can get same instance
+	 * Insure we can re-borrow the previously borrowed object from the current thread and that we get back the same instance
+	 *
+	 * @param verifyCanGetSameInstance the verify can get same instance
+	 *
 	 * @return the execution context
 	 */
 	public ExecutionContext verifyCanGetSameInstance(
@@ -130,7 +132,7 @@ public class ExecutionContext {
 		this.verifyCanGetSameInstance = verifyCanGetSameInstance;
 		return this;
 	}
-
+	
 	public <V, K> void validate(IPooledObject<V, K> borrowedObject) {
 		if (validator != null)
 			validator.validate(borrowedObject);

--- a/src/test/java/org/paceys/kbop/ExecutionContext.java
+++ b/src/test/java/org/paceys/kbop/ExecutionContext.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ExecutionContext {
 	
-	public interface PostValidation {
+	interface PostValidation {
 		
 		<V, K> void validate(IPooledObject<V, K> borrowedObject);
 	}

--- a/src/test/java/org/paceys/kbop/ExecutionContext.java
+++ b/src/test/java/org/paceys/kbop/ExecutionContext.java
@@ -14,7 +14,7 @@ public class ExecutionContext {
 
 	public interface PostValidation {
 
-		<V> void validate(IPooledObject<V> borrowedObject);
+		<V, K> void validate(IPooledObject<V, K> borrowedObject);
 	}
 
 	/** Max time to block waiting for an Object in Milliseconds */
@@ -133,7 +133,7 @@ public class ExecutionContext {
 		return this;
 	}
 
-	public <V> void validate(IPooledObject<V> borrowedObject) {
+	public <V, K> void validate(IPooledObject<V, K> borrowedObject) {
 		if (validator != null)
 			validator.validate(borrowedObject);
 	}

--- a/src/test/java/org/paceys/kbop/ExecutionContext.java
+++ b/src/test/java/org/paceys/kbop/ExecutionContext.java
@@ -7,8 +7,6 @@ import org.pacesys.kbop.IPooledObject;
 /**
  * Concurrent Test Execution Context which allows for various options to be
  * passed through to a Runnable cutting down on Test Boiler Plate code
- * 
- * @author Jeremy Unruh
  */
 public class ExecutionContext {
 

--- a/src/test/java/org/paceys/kbop/KeyedMultiObjectPoolTest.java
+++ b/src/test/java/org/paceys/kbop/KeyedMultiObjectPoolTest.java
@@ -100,7 +100,7 @@ public class KeyedMultiObjectPoolTest extends
 	
 	private Set<Thread> createThreadedExecution(final String key,
 												int threadCount, final ExecutionContext context) {
-		Set<Thread> threads = new HashSet<Thread>(threadCount);
+		Set<Thread> threads = new HashSet<>(threadCount);
 		for (int i = 0; i < threadCount; i++) {
 			threads.add(new Thread(new Runnable() {
 				public void run() {
@@ -125,12 +125,12 @@ public class KeyedMultiObjectPoolTest extends
 	}
 	
 	private void validateBorrowFromPool(String key, ExecutionContext context) {
-		IPooledObject<String> obj = null;
+		IPooledObject<String, String> obj = null;
 		try {
 			obj = pool().borrow(key, context.maxWaitTime, TimeUnit.MILLISECONDS);
 			Thread.sleep(context.sleepTime);
 			if (context.verifyCanGetSameInstance) {
-				IPooledObject<String> obj2 = pool().borrow(key, context.maxWaitTime,
+				IPooledObject<String, String> obj2 = pool().borrow(key, context.maxWaitTime,
 						TimeUnit.MILLISECONDS);
 				assertThat(obj.equals(obj2)).isTrue();
 			}

--- a/src/test/java/org/paceys/kbop/KeyedMultiObjectPoolTest.java
+++ b/src/test/java/org/paceys/kbop/KeyedMultiObjectPoolTest.java
@@ -86,7 +86,7 @@ public class KeyedMultiObjectPoolTest extends
 		assertThat(metrics.getKeyCount()).isEqualTo(2);
 	}
 	
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testShutdown() {
 		testPoolSizes();
 		
@@ -94,9 +94,9 @@ public class KeyedMultiObjectPoolTest extends
 		try {
 			pool().borrow(POOL_KEY);
 		} catch (IllegalStateException e) {
-			throw e;
+			// OK
 		} catch (Exception e) {
-			e.printStackTrace();
+			fail(e.getMessage(), e);
 		}
 	}
 	
@@ -121,7 +121,7 @@ public class KeyedMultiObjectPoolTest extends
 			try {
 				t.join();
 			} catch (InterruptedException e) {
-				throw new RuntimeException(e.getMessage());
+				throw new RuntimeException(e.getMessage(), e);
 			}
 		}
 	}
@@ -140,7 +140,7 @@ public class KeyedMultiObjectPoolTest extends
 			context.validate(obj);
 		} catch (TimeoutException e) {
 			if (context.failIfUnableToBorrow)
-				fail("Unable to borrow object : " + e.getMessage());
+				fail("Unable to borrow object : " + e.getMessage(), e);
 			else
 				assertThat(pool().getPoolMetrics().getKeyMetrics(key)
 						.getBorrowedCount() == MAX_ITEMS_PER_KEY).isTrue();

--- a/src/test/java/org/paceys/kbop/KeyedMultiObjectPoolTest.java
+++ b/src/test/java/org/paceys/kbop/KeyedMultiObjectPoolTest.java
@@ -1,14 +1,14 @@
 package org.paceys.kbop;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import org.junit.Test;
 import org.pacesys.kbop.IKeyedObjectPool;
 import org.pacesys.kbop.IPooledObject;
 import org.pacesys.kbop.PoolMetrics.PoolMultiMetrics;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -45,7 +45,7 @@ public class KeyedMultiObjectPoolTest extends
 		
 		// Run again and invalidate vs release
 		executeAndWait(createThreadedExecution(POOL_KEY, MAX_ITEMS_PER_KEY, ExecutionContext.get().failIfUnableToBorrow(true)
-						.reusableAfterAllocation(false).sleepTime(20)));
+				.reusableAfterAllocation(false).sleepTime(20)));
 		metrics = pool().getPoolMetrics();
 		assertThat(metrics.getKeyMetrics(POOL_KEY).getAllocationSize()).isZero();
 	}

--- a/src/test/java/org/paceys/kbop/KeyedMultiObjectPoolTest.java
+++ b/src/test/java/org/paceys/kbop/KeyedMultiObjectPoolTest.java
@@ -32,6 +32,7 @@ public class KeyedMultiObjectPoolTest extends
 	}
 	
 	@Test
+	@SuppressWarnings("ConstantConditions")
 	public void allocationSizeShouldNotGrowAfterInvalidate() {
 		maxAllocatedTestAgainstSameKey();
 		
@@ -60,6 +61,7 @@ public class KeyedMultiObjectPoolTest extends
 	}
 	
 	@Test
+	@SuppressWarnings("ConstantConditions")
 	public void highConcurrencyVolumeTest() {
 		maxAllocatedTestAgainstSameKey();
 		
@@ -124,6 +126,7 @@ public class KeyedMultiObjectPoolTest extends
 		}
 	}
 	
+	@SuppressWarnings("ConstantConditions")
 	private void validateBorrowFromPool(String key, ExecutionContext context) {
 		IPooledObject<String, String> obj = null;
 		try {

--- a/src/test/java/org/paceys/kbop/KeyedSingleObjectPoolTest.java
+++ b/src/test/java/org/paceys/kbop/KeyedSingleObjectPoolTest.java
@@ -41,7 +41,9 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 						obj.release();
 						fail("Object was obtained");
 					} catch (Exception e) {
-						assertThat(e instanceof TimeoutException).isTrue();
+						if (!(e instanceof TimeoutException)) {
+							fail(e.getMessage(), e);
+						}
 					}
 				}
 				
@@ -71,7 +73,7 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 					Thread.sleep(20);
 					assertThat(pool().borrow(POOL_KEY)).isNotNull();
 				} catch (Exception e) {
-					fail("Failed to obtain Object: " + Thread.currentThread().getName());
+					fail("Failed to obtain Object: " + Thread.currentThread().getName(), e);
 				} finally {
 					if (obj != null)
 						obj.release();
@@ -126,7 +128,7 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 		} catch (IllegalStateException e) {
 			throw e;
 		} catch (Exception e) {
-			e.printStackTrace();
+			fail(e.getMessage(), e);
 		}
 	}
 	

--- a/src/test/java/org/paceys/kbop/KeyedSingleObjectPoolTest.java
+++ b/src/test/java/org/paceys/kbop/KeyedSingleObjectPoolTest.java
@@ -30,13 +30,13 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 	public void waitForObjectWithTimeoutTest() throws Exception {
 		singleBorrowAndRelease();
 		
-		IPooledObject<String> obj = pool().borrow(POOL_KEY);
+		IPooledObject<String, String> obj = pool().borrow(POOL_KEY);
 		try {
 			ExecutorService es = Executors.newSingleThreadExecutor();
 			Future<?> f = es.submit(new Runnable() {
 				public void run() {
 					try {
-						IPooledObject<String> obj = pool().borrow(POOL_KEY, 500,
+						IPooledObject<String, String> obj = pool().borrow(POOL_KEY, 500,
 								TimeUnit.MILLISECONDS);
 						obj.release();
 						fail("Object was obtained");
@@ -64,7 +64,7 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 		
 		Runnable r = new Runnable() {
 			public void run() {
-				IPooledObject<String> obj = null;
+				IPooledObject<String, String> obj = null;
 				try {
 					obj = pool().borrow(POOL_KEY);
 					assertThat(obj).isNotNull();
@@ -88,7 +88,7 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 
 	@Test
 	public void singleBorrowAndRelease() throws Exception {
-		IPooledObject<String> obj = pool().borrow(POOL_KEY);
+		IPooledObject<String, String> obj = pool().borrow(POOL_KEY);
 		assertThat(obj).isNotNull();
 		pool().release(obj);
 		verifyMetrics();
@@ -139,7 +139,7 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 		TestLifecycleFactory factory = new TestLifecycleFactory();
 		IKeyedObjectPool<String, Boolean> pool = Pools.createPool(factory);
 
-		IPooledObject<Boolean> obj = pool.borrow(POOL_KEY);
+		IPooledObject<Boolean, String> obj = pool.borrow(POOL_KEY);
 		obj.release();
 		obj = pool.borrow(POOL_KEY);
 		obj.invalidate();

--- a/src/test/java/org/paceys/kbop/KeyedSingleObjectPoolTest.java
+++ b/src/test/java/org/paceys/kbop/KeyedSingleObjectPoolTest.java
@@ -94,7 +94,7 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 		verifyMetrics();
 	}
 	
-	public void verifyMetrics() throws Exception {
+	private void verifyMetrics() {
 		PoolMetrics metrics = pool().getPoolMetrics();
 		assertThat(metrics).isNotNull();
 		assertThat(metrics.getBorrowedCount()).isZero();

--- a/src/test/java/org/paceys/kbop/KeyedSingleObjectPoolTest.java
+++ b/src/test/java/org/paceys/kbop/KeyedSingleObjectPoolTest.java
@@ -95,7 +95,7 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 	}
 	
 	public void verifyMetrics() throws Exception {
-		PoolMetrics<String> metrics = pool().getPoolMetrics();
+		PoolMetrics metrics = pool().getPoolMetrics();
 		assertThat(metrics).isNotNull();
 		assertThat(metrics.getBorrowedCount()).isZero();
 		assertThat(metrics.getWaitingCount()).isZero();
@@ -106,7 +106,7 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 	public void testMetrics() throws Exception {
 		manyThreadsBlockingUntilObtained();
 		
-		PoolMetrics<String> metrics = pool().getPoolMetrics();
+		PoolMetrics metrics = pool().getPoolMetrics();
 		assertThat(metrics).isNotNull();
 		assertThat(metrics.getBorrowedCount()).isZero();
 		assertThat(metrics.getWaitingCount()).isZero();

--- a/src/test/java/org/paceys/kbop/KeyedSingleObjectPoolTest.java
+++ b/src/test/java/org/paceys/kbop/KeyedSingleObjectPoolTest.java
@@ -18,14 +18,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool.Single<String, String>> {
-
+	
 	/**
 	 * Instantiates a new keyed single object pool test.
 	 */
 	public KeyedSingleObjectPoolTest() {
 		super(1);
 	}
-
+	
 	@Test
 	public void waitForObjectWithTimeoutTest() throws Exception {
 		singleBorrowAndRelease();
@@ -44,20 +44,20 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 						assertThat(e instanceof TimeoutException).isTrue();
 					}
 				}
-
+				
 			});
-
+			
 			// Test that the main thread can still acquire the object since it owns
 			// the contract and hasn't releasd it yet
 			assertThat(pool().borrow(POOL_KEY)).isNotNull();
-
+			
 			// block until thread is done
 			f.get();
 		} finally {
 			obj.release();
 		}
 	}
-
+	
 	@Test
 	public void manyThreadsBlockingUntilObtained() throws Exception {
 		waitForObjectWithTimeoutTest();
@@ -85,7 +85,7 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 		es.awaitTermination(2, TimeUnit.SECONDS);
 		verifyMetrics();
 	}
-
+	
 	@Test
 	public void singleBorrowAndRelease() throws Exception {
 		IPooledObject<String, String> obj = pool().borrow(POOL_KEY);
@@ -112,7 +112,7 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 		assertThat(metrics.getWaitingCount()).isZero();
 		assertThat(metrics.getKeyCount()).isEqualTo(1);
 	}
-
+	
 	/**
 	 * Tests shutting down the pool and not allowing any more allocations
 	 */
@@ -129,41 +129,40 @@ public class KeyedSingleObjectPoolTest extends AbstractPoolTest<IKeyedObjectPool
 			e.printStackTrace();
 		}
 	}
-
+	
 	/**
-	 * Tests the Factory Lifecycle to insure the pool is calling factory during
-	 * each phase within the objects lifecycle
+	 * Tests the Factory Lifecycle to insure the pool is calling factory during each phase within the objects lifecycle
 	 */
 	@Test
 	public void testObjectLifecycle() throws Exception {
 		TestLifecycleFactory factory = new TestLifecycleFactory();
 		IKeyedObjectPool<String, Boolean> pool = Pools.createPool(factory);
-
+		
 		IPooledObject<Boolean, String> obj = pool.borrow(POOL_KEY);
 		obj.release();
 		obj = pool.borrow(POOL_KEY);
 		obj.invalidate();
-
+		
 		assertThat(factory.lifecycleCount).isEqualTo(4);
 	}
-
+	
 	static class TestLifecycleFactory implements
 			IPoolObjectFactory<String, Boolean> {
 		int lifecycleCount;
-
+		
 		public Boolean create(PoolKey<String> key) {
 			lifecycleCount++;
 			return true;
 		}
-
+		
 		public void activate(Boolean object) {
 			lifecycleCount++;
 		}
-
+		
 		public void passivate(Boolean object) {
 			lifecycleCount++;
 		}
-
+		
 		public void destroy(Boolean object) {
 			lifecycleCount++;
 		}


### PR DESCRIPTION
This is an overhaul to modernize the code a bit. It is compatible with Java 1.7+, introduces Lombok to get rid of boilerplate code and moves from ngtest to junit+assertJ for better IDE integration. For quality and bugs detection, I've added Nullability annotations and Spotbugs to the Maven build.

Here's the complete list of quality-of-life improvements:

- fixed a bunch of generics removed obsolete casts
- added lombok to get rid of boilerplate code
- moved to Java 1.7, utilizing diamond operator
- removed Clonable and Serializable dead weight
- removed a gazillion static warnings
- added JetBrains' nullability annotations for bug checking (adds no dependency on JetBrains)
- added automatic nullability-checks in all methods using maven plugin
- Added Spotbugs to build cycle
- fixed visiblity of the internal methods (all lowest possible while maintaining same public API)
- applied standard formatting
- fixed potential NullpointerExceptions
- updated maven config
- switched to JUnit+AssertJ (works in IDE as well)
- removed @Author entries from javadoc (we have CVS for that and the Maven author entry)

Note that the build fails with this because Spotbugs found a possible bug I can't judge/solve myself.

I hope you find it useful. If not, I'll fork your project and go from there, no hard feelings 👍 